### PR TITLE
Fixing a potential null reference

### DIFF
--- a/MobileAppsCrm-preview/server/ActivityLoggerBackend-preview/Models/UppercaseGuidConverter.cs
+++ b/MobileAppsCrm-preview/server/ActivityLoggerBackend-preview/Models/UppercaseGuidConverter.cs
@@ -26,6 +26,7 @@ namespace ActivityLoggerBackend
             if (value == null)
             {
                 writer.WriteNull();
+                return;
             }
 
             writer.WriteValue(value.ToString().ToUpperInvariant());

--- a/MobileServicesCrm/server/ActivityLoggerBackend/Models/UppercaseGuidConverter.cs
+++ b/MobileServicesCrm/server/ActivityLoggerBackend/Models/UppercaseGuidConverter.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Windows.Azure.Service.DynamicsCrm.WebHost
             if (value == null)
             {
                 writer.WriteNull();
+                return;
             }
 
             writer.WriteValue(value.ToString().ToUpperInvariant());


### PR DESCRIPTION
Noticed that the UppercaseGuidConverter class will throw a NullReferenceException if we don't return from the method earlier. Submitting fix for both Mobile Apps and Mobile Services.
